### PR TITLE
[WIP] Update Vagrantfile to Ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Usage
 4. Update cookbook dependencies with `git submodule init` and then `git submodule update --remote`
 5. Run `vagrant up` to start the virtual machine
 6. Connect in your browser to http://localhost:3000
-7. Username is `vagrant` with password `vagrant` you can get root access with `sudo -i`
+7. Username is `admin@example.org` with password `test123` you can get root access with `sudo -i`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,10 +11,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   ##############
 
   # Run with Ubuntu 14.04
-  config.vm.box = "ubuntu-14.04"
+  config.vm.box = "ubuntu-16.04"
 
   # Download URL Ubuntu 14.04
-  config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box"
+  config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-16.04_chef-provisionerless.box"
 
   ###################
   ## Network configuration


### PR DESCRIPTION
Follow up to https://github.com/frab/chef-frab/pull/1 — upgrades ubuntu to 16.04. Because frab cannot be installed on 14.04.

Needs changing the `cookbooks` endpoint to frab/chef-frab. Will do that after the pull request above is merged.